### PR TITLE
Fix minor bug in DeleteHandler messages

### DIFF
--- a/305.Application/Base/Handler/DeleteHandler.cs
+++ b/305.Application/Base/Handler/DeleteHandler.cs
@@ -66,8 +66,10 @@ public class DeleteHandler
 			// عملیات حذف (در صورت نیاز)
 			onDeleteAsync?.Invoke(entity);
 
-			var committed = await _unitOfWork.CommitAsync(cancellationToken);
-			return !committed ? Responses.ExceptionFail<TResult>(default, $"{entityName} ویرایش نشد", 500) : Responses.ChangeOrDelete<TResult>(default, $"{entityName} با موفقیت ویرایش شد");
+                        var committed = await _unitOfWork.CommitAsync(cancellationToken);
+                        return !committed
+                                ? Responses.ExceptionFail<TResult>(default, $"{entityName} حذف نشد", 500)
+                                : Responses.ChangeOrDelete<TResult>(default, $"{entityName} با موفقیت حذف شد");
 		}
 		catch (OperationCanceledException)
 		{


### PR DESCRIPTION
## Summary
- fix incorrect Farsi messages for delete operations

## Testing
- `dotnet test --no-build --nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684aefef939c8326928294fd153f2dc4