### PR TITLE
Enhance refresh token handler unit test

### DIFF
--- a/305.Tests.Unit/TestHandlers/AdminAuthTests/AdminRefreshCommandHandlerTests.cs
+++ b/305.Tests.Unit/TestHandlers/AdminAuthTests/AdminRefreshCommandHandlerTests.cs
@@ -59,10 +59,12 @@ public class AdminRefreshCommandHandlerTests
 		// Act
 		var result = await handler.Handle(new AdminRefreshCommand(), CancellationToken.None);
 
-		// Assert
-		Assert.True(result.is_success);
-		Assert.Equal(accessToken, result.data.access_token);
-	}
+                // Assert
+                Assert.True(result.is_success);
+                Assert.Equal(accessToken, result.data.access_token);
+                tokenServiceMock.Verify(t => t.GenerateAccessToken(user, It.IsAny<List<string>>(), null), Times.Once);
+                unitOfWorkMock.Verify(u => u.TokenBlacklistRepository.ExistsAsync(It.IsAny<Expression<Func<BlacklistedToken, bool>>>()), Times.Once);
+        }
 
 	[Fact]
 	public async Task Handle_ShouldFail_WhenNoRefreshTokenInCookie()


### PR DESCRIPTION
## Summary
- verify access token generation and blacklist check in `AdminRefreshCommandHandlerTests`

## Testing
- `dotnet test 305.Tests.Unit/305.Tests.Unit.csproj --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b09a515b48326a84b1a48b0c5d570