### PR TITLE
Fix Middleware path and namespaces

### DIFF
--- a/305.WebApi/Assistants/Middleware/HangfireAuthorizationFilter.cs
+++ b/305.WebApi/Assistants/Middleware/HangfireAuthorizationFilter.cs
@@ -1,6 +1,6 @@
 ﻿using Hangfire.Dashboard;
 
-namespace _305.WebApi.Assistants.Middlewar
+namespace _305.WebApi.Assistants.Middleware
 {
 	/// <summary>
 	/// فیلتر مجوز برای دسترسی به داشبورد Hangfire، که تنها کاربران احراز هویت‌شده

--- a/305.WebApi/Assistants/Middleware/LoggingMiddleware.cs
+++ b/305.WebApi/Assistants/Middleware/LoggingMiddleware.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using System.Text;
 
-namespace _305.WebApi.Assistants.Middlewar;
+namespace _305.WebApi.Assistants.Middleware;
 
 /// <summary>
 /// Middleware برای لاگ گرفتن درخواست‌ها در فایل متنی.

--- a/305.WebApi/Assistants/Middleware/TokenBlacklistMiddleware.cs
+++ b/305.WebApi/Assistants/Middleware/TokenBlacklistMiddleware.cs
@@ -1,7 +1,7 @@
 ﻿using _305.Application.IUOW;
 using Serilog;
 
-namespace _305.WebApi.Assistants.Middlewar;
+namespace _305.WebApi.Assistants.Middleware;
 
 /// <summary>
 /// Middleware برای جلوگیری از استفاده توکن‌هایی که در لیست سیاه قرار گرفته‌اند.

--- a/305.WebApi/Program.cs
+++ b/305.WebApi/Program.cs
@@ -5,7 +5,7 @@ using _305.BuildingBlocks.IService;
 using _305.BuildingBlocks.Service;
 using _305.Infrastructure.Persistence;
 using _305.Infrastructure.Service;
-using _305.WebApi.Assistants.Middlewar;
+using _305.WebApi.Assistants.Middleware;
 using _305.WebApi.Assistants.Permission;
 using Hangfire;
 using Microsoft.AspNetCore.Authentication.JwtBearer;


### PR DESCRIPTION
## Summary
- fix folder spelling from `Middlewar` to `Middleware`
- update namespace declarations for middleware classes
- update using statement in Program.cs

## Testing
- `dotnet build 305.WebApi/305.WebApi.sln` *(fails: command not found)*
- `dotnet test 305.WebApi/305.WebApi.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0a88cdd48326a73786ca7c8d05bd