### PR TITLE
Change lockout config to TimeSpan

### DIFF
--- a/305.Application/Features/AdminAuthFeatures/Handler/AdminLoginCommandHandler.cs
+++ b/305.Application/Features/AdminAuthFeatures/Handler/AdminLoginCommandHandler.cs
@@ -36,8 +36,8 @@ public class AdminLoginCommandHandler(
 				user.failed_login_count++;
 				if (user.failed_login_count >= lockOutConfig.FailedLoginLimit)
 				{
-					user.is_locked_out = true;
-					user.lock_out_end_time = lockOutConfig.Duration; // قفل موقت
+                                        user.is_locked_out = true;
+                                        user.lock_out_end_time = DateTime.Now.Add(lockOutConfig.LockoutDuration); // قفل موقت
 				}
 				unitOfWork.UserRepository.Update(user);
 				await unitOfWork.CommitAsync(cancellationToken);

--- a/305.BuildingBlocks/Configurations/LockoutConfig.cs
+++ b/305.BuildingBlocks/Configurations/LockoutConfig.cs
@@ -16,8 +16,8 @@ public class LockoutConfig
 	/// </summary>
 	public int FailedLoginLimit { get; set; } = 4;
 
-	/// <summary>
-	/// مدت‌زمان قفل شدن حساب پس از رسیدن به حد مجاز تلاش‌های ناموفق
-	/// </summary>
-	public DateTime Duration { get; set; } = DateTime.Now.AddMinutes(1);
+        /// <summary>
+        /// مدت‌زمان قفل شدن حساب پس از رسیدن به حد مجاز تلاش‌های ناموفق
+        /// </summary>
+        public TimeSpan LockoutDuration { get; set; } = TimeSpan.FromMinutes(1);
 }

--- a/305.WebApi/appsettings.json
+++ b/305.WebApi/appsettings.json
@@ -25,7 +25,7 @@
   },
   "Lockout": {
     "FailedLoginLimit": 4,
-    "Duration": "00:01:00"
+    "LockoutDuration": "00:01:00"
   },
   "ConnectionStrings": {
     "ServerDbConnection": "Server=.;Database=305_db;Integrated Security=True;Trusted_Connection=True;TrustServerCertificate=True",


### PR DESCRIPTION
## Summary
- update `LockoutConfig` to use `TimeSpan` instead of `DateTime`
- rename `Duration` in appsettings to `LockoutDuration`
- update login handler to use new duration field

## Testing
- `dotnet build 305.WebApi/305.WebApi.sln -c Release` *(fails: `dotnet` not found)*
- `dotnet test 305.WebApi/305.WebApi.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0aa1de388326b22cf26ef2e86a85