### PR TITLE
Refactor auth handlers with helper methods

### DIFF
--- a/305.Application/Features/AdminAuthFeatures/Handler/AdminRefreshCommandHandler.cs
+++ b/305.Application/Features/AdminAuthFeatures/Handler/AdminRefreshCommandHandler.cs
@@ -4,6 +4,7 @@ using _305.Application.Features.AdminAuthFeatures.Response;
 using _305.Application.IService;
 using _305.Application.IUOW;
 using _305.BuildingBlocks.Configurations;
+using _305.Application.Helpers;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Serilog;
@@ -22,23 +23,22 @@ public class AdminRefreshCommandHandler(
     {
         try
         {
-            var context = httpContextAccessor.HttpContext;
-            if (context.Request.Cookies.TryGetValue("jwt", out var refreshToken))
+            var refreshToken = ReadRefreshToken();
+            if (refreshToken != null)
             {
                 var user = await unitOfWork.UserRepository.FindSingle(x => x.refresh_token == refreshToken);
                 if (user == null || user.refresh_token_expiry_time < DateTime.Now)
                 {
-                    context.Response.Cookies.Delete("jwt");
+                    DeleteRefreshTokenCookie();
                     return Responses.Fail<LoginResponse>(null, message: "توکن نامعتبر است و یا منقضی شده است", code: 401);
                 }
 
                 var role = unitOfWork.UserRoleRepository.FindList(x => x.userid == user.id);
-                var token = "";
-                do
-                {
-                    token = jwtService.GenerateAccessToken(user, role.Select(x => x.role?.name).ToList());
-                }
-                while (await unitOfWork.TokenBlacklistRepository.ExistsAsync(x => x.token == token));
+                var token = await JwtTokenHelper.GenerateUniqueAccessToken(
+                    jwtService,
+                    unitOfWork,
+                    user,
+                    role.Select(x => x.role?.name).ToList());
                 return Responses.Success<LoginResponse>(new LoginResponse()
                 {
                     access_token = token,
@@ -55,5 +55,22 @@ public class AdminRefreshCommandHandler(
             Log.Error(ex, "خطا در زمان ایجاد موجودیت: {Message}", ex.Message);
             return Responses.ExceptionFail<LoginResponse>(null, null);
         }
+    }
+
+    /// <summary>
+    /// خواندن رفرش توکن از کوکی
+    /// </summary>
+    private string? ReadRefreshToken()
+    {
+        var context = httpContextAccessor.HttpContext;
+        return context.Request.Cookies.TryGetValue("jwt", out var token) ? token : null;
+    }
+
+    /// <summary>
+    /// حذف کوکی مربوط به رفرش توکن
+    /// </summary>
+    private void DeleteRefreshTokenCookie()
+    {
+        httpContextAccessor.HttpContext?.Response.Cookies.Delete("jwt");
     }
 }

--- a/305.Application/Helpers/JwtTokenHelper.cs
+++ b/305.Application/Helpers/JwtTokenHelper.cs
@@ -1,0 +1,43 @@
+using _305.Application.IService;
+using _305.Application.IUOW;
+using _305.Domain.Entity;
+
+namespace _305.Application.Helpers;
+
+/// <summary>
+/// توابع کمکی برای تولید توکن‌های یکتا
+/// </summary>
+public static class JwtTokenHelper
+{
+    /// <summary>
+    /// تولید توکن دسترسی که در بلک لیست وجود ندارد
+    /// </summary>
+    public static async Task<string> GenerateUniqueAccessToken(
+        IJwtService jwtService,
+        IUnitOfWork unitOfWork,
+        User user,
+        List<string?> roles)
+    {
+        string token;
+        do
+        {
+            token = jwtService.GenerateAccessToken(user, roles);
+        } while (await unitOfWork.TokenBlacklistRepository.ExistsAsync(x => x.token == token));
+        return token;
+    }
+
+    /// <summary>
+    /// تولید رفرش توکن یکتا که در دیتابیس موجود نباشد
+    /// </summary>
+    public static async Task<string> GenerateUniqueRefreshToken(
+        IJwtService jwtService,
+        IUnitOfWork unitOfWork)
+    {
+        string refreshToken;
+        do
+        {
+            refreshToken = jwtService.GenerateRefreshToken();
+        } while (await unitOfWork.UserRepository.ExistsAsync(x => x.refresh_token == refreshToken));
+        return refreshToken;
+    }
+}


### PR DESCRIPTION
## Summary
- add `JwtTokenHelper` for reusable token generation
- refactor login handler to use small methods
- refactor refresh handler and add cookie helper methods

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b33efe644832693e8dfadfd7903bc