### PR TITLE
Refactor auth cookie handling

### DIFF
--- a/305.Application/Features/AdminAuthFeatures/Handler/AdminLoginCommandHandler.cs
+++ b/305.Application/Features/AdminAuthFeatures/Handler/AdminLoginCommandHandler.cs
@@ -6,6 +6,7 @@ using _305.Application.IUOW;
 using _305.BuildingBlocks.Configurations;
 using _305.BuildingBlocks.Security;
 using _305.Application.Helpers;
+using _305.BuildingBlocks.Helper;
 using _305.Domain.Entity;
 using MediatR;
 using Microsoft.AspNetCore.Http;
@@ -54,22 +55,13 @@ public class AdminLoginCommandHandler(
             unitOfWork.UserRepository.Update(user);
             await unitOfWork.CommitAsync(cancellationToken);
 
-            // ذخیره توکن در کوکی
-            var cookieOptions = new CookieOptions
-            {
-                HttpOnly = true,
-                Secure = false, // موقتا غیر فعال کن برای تست
-                SameSite = SameSiteMode.Lax, // یا None اگر لازم بود
-                Expires = DateTime.Now.AddMinutes(Config.AdminRefreshTokenLifetime.TotalMinutes)
-            };
+            // ذخیره توکن در کوکی به صورت یکسان
             var context = httpContextAccessor.HttpContext;
-            context.Response.Cookies.Append("jwt", refreshToken, new CookieOptions
-            {
-                HttpOnly = true,
-                Secure = false, // موقتا غیر فعال کن برای تست
-                SameSite = SameSiteMode.Lax, // یا None اگر لازم بود
-                Expires = DateTime.Now.AddMinutes(Config.AdminRefreshTokenLifetime.TotalMinutes)
-            });
+            CookieHelper.SetJwtCookie(
+                context.Response,
+                refreshToken,
+                Config.AdminRefreshTokenLifetime,
+                secure: false);
 
             return Responses.Success(data:
                 new LoginResponse()

--- a/305.Application/Features/AdminAuthFeatures/Handler/AdminLogoutCommandHandler.cs
+++ b/305.Application/Features/AdminAuthFeatures/Handler/AdminLogoutCommandHandler.cs
@@ -47,7 +47,7 @@ public class AdminLogoutCommandHandler(
                 });
 
                 // حذف کوکی از مرورگر
-                context.Response.Cookies.Delete("jwt");
+                CookieHelper.DeleteJwtCookie(context.Response);
                 user.refresh_token = null;
                 user.refresh_token_expiry_time = DateTime.MinValue;
 

--- a/305.BuildingBlocks/Helper/CookieHelper.cs
+++ b/305.BuildingBlocks/Helper/CookieHelper.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Http;
+
+namespace _305.BuildingBlocks.Helper;
+
+/// <summary>
+/// ابزار کمکی برای مدیریت کوکی‌های مربوط به JWT.
+/// </summary>
+public static class CookieHelper
+{
+    /// <summary>
+    /// نام کوکی JWT
+    /// </summary>
+    private const string JwtCookieName = "jwt";
+
+    /// <summary>
+    /// افزودن کوکی رفرش توکن با تنظیمات پیش‌فرض.
+    /// </summary>
+    /// <param name="response">پاسخ HTTP برای افزودن کوکی</param>
+    /// <param name="token">رفرش توکن</param>
+    /// <param name="lifetime">مدت زمان اعتبار کوکی</param>
+    /// <param name="secure">استفاده از HTTPS</param>
+    public static void SetJwtCookie(HttpResponse response, string token, TimeSpan lifetime, bool secure = false)
+    {
+        response.Cookies.Append(JwtCookieName, token, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = secure,
+            SameSite = SameSiteMode.Lax,
+            Expires = DateTime.UtcNow.Add(lifetime)
+        });
+    }
+
+    /// <summary>
+    /// خواندن مقدار کوکی JWT.
+    /// </summary>
+    public static string? ReadJwtCookie(HttpRequest request)
+    {
+        return request.Cookies.TryGetValue(JwtCookieName, out var token) ? token : null;
+    }
+
+    /// <summary>
+    /// حذف کوکی JWT.
+    /// </summary>
+    public static void DeleteJwtCookie(HttpResponse response)
+    {
+        response.Cookies.Delete(JwtCookieName);
+    }
+}


### PR DESCRIPTION
## Summary
- centralize cookie actions in `CookieHelper`
- use new helper in auth handlers

## Testing
- `dotnet test --no-build 305.Tests.Unit/305.Tests.Unit.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d324ca75c8326ad85797320d2a9a0