### PR TITLE
Improve 305.WebApi startup and logging

### DIFF
--- a/305.BuildingBlocks/Configurations/RequestLoggingConfig.cs
+++ b/305.BuildingBlocks/Configurations/RequestLoggingConfig.cs
@@ -1,0 +1,18 @@
+namespace _305.BuildingBlocks.Configurations;
+
+/// <summary>
+/// تنظیمات مربوط به لاگ‌برداری درخواست‌های ورودی.
+/// </summary>
+public class RequestLoggingConfig
+{
+    /// <summary>
+    /// نام بخشی که در فایل تنظیمات برای این پیکربندی استفاده می‌شود.
+    /// </summary>
+    public const string SectionName = "RequestLogging";
+
+    /// <summary>
+    /// مسیر ذخیره فایل لاگ درخواست‌ها.
+    /// </summary>
+    public string FilePath { get; set; } = Path.Combine(Directory.GetCurrentDirectory(), "logs", "requests.txt");
+}
+

--- a/305.WebApi/Assistants/Middleware/LoggingMiddleware.cs
+++ b/305.WebApi/Assistants/Middleware/LoggingMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text;
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using _305.BuildingBlocks.Configurations;
 using System.IO;
 
 namespace _305.WebApi.Assistants.Middleware;
@@ -12,11 +13,10 @@ public class LoggingMiddleware
     private readonly RequestDelegate _next;
     private readonly string _logPath;
 
-    public LoggingMiddleware(RequestDelegate next, IConfiguration configuration)
+    public LoggingMiddleware(RequestDelegate next, IOptions<RequestLoggingConfig> options)
     {
         _next = next;
-        _logPath = configuration["RequestLogging:FilePath"] ??
-                    Path.Combine(Directory.GetCurrentDirectory(), "logs", "requests.txt");
+        _logPath = options.Value.FilePath;
         EnsureLogDirectoryExists(_logPath);
     }
 
@@ -51,3 +51,4 @@ public class LoggingMiddleware
         await stream.WriteAsync(logBytes, 0, logBytes.Length);
     }
 }
+

--- a/305.WebApi/Assistants/Permission/PermissionSeedHostedService.cs
+++ b/305.WebApi/Assistants/Permission/PermissionSeedHostedService.cs
@@ -1,0 +1,28 @@
+using _305.WebApi.Assistants.Permission;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+
+namespace _305.WebApi.Assistants.Permission;
+
+/// <summary>
+/// Hosted service برای همگام‌سازی مجوزها هنگام راه‌اندازی برنامه.
+/// </summary>
+public class PermissionSeedHostedService(IServiceProvider serviceProvider) : IHostedService
+{
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = serviceProvider.CreateScope();
+            var seeder = scope.ServiceProvider.GetRequiredService<PermissionSeeder>();
+            await seeder.SyncPermissionsAsync();
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "error during seeding permissions");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+

--- a/305.WebApi/Assistants/Tasks/TokenCleanupTask.cs
+++ b/305.WebApi/Assistants/Tasks/TokenCleanupTask.cs
@@ -9,8 +9,6 @@ public class TokenCleanupTask
 {
     /// <summary>
     /// اجرای پاک‌سازی توکن‌هایی که تاریخ انقضای آن‌ها گذشته است.
-    // ReSharper disable once InvalidXmlDocComment
-    /// </param>
     /// <param name="unitOfWork">واحد کاری برای دسترسی به ریپازیتوری‌ها و ثبت تغییرات.</param>
     public async Task ExecuteAsync(IUnitOfWork unitOfWork)
     {
@@ -25,3 +23,4 @@ public class TokenCleanupTask
         await unitOfWork.CommitAsync(CancellationToken.None);
     }
 }
+

--- a/305.WebApi/Controllers/Admin/AdminAuthController.cs
+++ b/305.WebApi/Controllers/Admin/AdminAuthController.cs
@@ -27,3 +27,5 @@ public class AdminAuthController(IMediator mediator) : BaseController(mediator)
     public Task<IActionResult> Profile([FromQuery] GetUserProfileQuery query, CancellationToken cancellationToken) =>
         ExecuteQuery(query, cancellationToken);
 }
+
+

--- a/305.WebApi/Controllers/Admin/AdminBlogCategoryController.cs
+++ b/305.WebApi/Controllers/Admin/AdminBlogCategoryController.cs
@@ -35,3 +35,4 @@ public class AdminBlogCategoryController(IMediator mediator) : BaseController(me
     public Task<IActionResult> Delete([FromForm] DeleteCategoryCommand command, CancellationToken cancellationToken) =>
         ExecuteCommand<DeleteCategoryCommand, ResponseDto<string>>(command, cancellationToken);
 }
+

--- a/305.WebApi/Controllers/Admin/AdminBlogController.cs
+++ b/305.WebApi/Controllers/Admin/AdminBlogController.cs
@@ -30,3 +30,4 @@ public class AdminBlogController(IMediator mediator) : BaseController(mediator)
     public Task<IActionResult> Delete([FromForm] DeleteBlogCommand command, CancellationToken cancellationToken) =>
         ExecuteCommand<DeleteBlogCommand, ResponseDto<string>>(command, cancellationToken);
 }
+

--- a/305.WebApi/Controllers/Admin/AdminPermissionController.cs
+++ b/305.WebApi/Controllers/Admin/AdminPermissionController.cs
@@ -34,3 +34,4 @@ public class AdminPermissionController(IMediator mediator) : BaseController(medi
     public Task<IActionResult> Delete([FromForm] DeletePermissionCommand command, CancellationToken cancellationToken) =>
         ExecuteCommand<DeletePermissionCommand, ResponseDto<string>>(command, cancellationToken);
 }
+

--- a/305.WebApi/Controllers/Admin/AdminRoleController.cs
+++ b/305.WebApi/Controllers/Admin/AdminRoleController.cs
@@ -34,3 +34,4 @@ public class AdminRoleController(IMediator mediator) : BaseController(mediator)
     public Task<IActionResult> Delete([FromForm] DeleteRoleCommand command, CancellationToken cancellationToken) =>
         ExecuteCommand<DeleteRoleCommand, ResponseDto<string>>(command, cancellationToken);
 }
+

--- a/305.WebApi/Controllers/Admin/AdminRolePermissionController.cs
+++ b/305.WebApi/Controllers/Admin/AdminRolePermissionController.cs
@@ -30,3 +30,4 @@ public class AdminRolePermissionController(IMediator mediator) : BaseController(
     public Task<IActionResult> Delete([FromForm] DeleteRolePermissionCommand command, CancellationToken cancellationToken) =>
         ExecuteCommand<DeleteRolePermissionCommand, ResponseDto<string>>(command, cancellationToken);
 }
+

--- a/305.WebApi/Controllers/Admin/AdminUserController.cs
+++ b/305.WebApi/Controllers/Admin/AdminUserController.cs
@@ -30,3 +30,4 @@ public class AdminUserController(IMediator mediator) : BaseController(mediator)
     public Task<IActionResult> Delete([FromForm] DeleteAdminUserCommand command, CancellationToken cancellationToken) =>
         ExecuteCommand<DeleteAdminUserCommand, ResponseDto<string>>(command, cancellationToken);
 }
+

--- a/305.WebApi/Controllers/Admin/AdminUserRoleController.cs
+++ b/305.WebApi/Controllers/Admin/AdminUserRoleController.cs
@@ -30,3 +30,5 @@ public class AdminUserUserRoleController(IMediator mediator) : BaseController(me
     public Task<IActionResult> Delete([FromForm] DeleteUserRoleCommand command, CancellationToken cancellationToken) =>
         ExecuteCommand<DeleteUserRoleCommand, ResponseDto<string>>(command, cancellationToken);
 }
+
+


### PR DESCRIPTION
## Summary
- add RequestLoggingConfig
- refactor LoggingMiddleware to use strong typed options
- host permission seeding in a hosted service
- clean up TokenCleanupTask XML doc
- trim startup logic and add PermissionSeedHostedService
- add trailing newlines for all admin controllers

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d54475668832688c1a15a3d7645af