### PR TITLE
Improve integration test infrastructure

### DIFF
--- a/305.Tests.Integration/Base/Helpers/TestDataHelper.cs
+++ b/305.Tests.Integration/Base/Helpers/TestDataHelper.cs
@@ -2,6 +2,7 @@ using _305.Application.Base.Response;
 using _305.Application.Features.AdminAuthFeatures.Response;
 using _305.Application.Features.BlogCategoryFeatures.Response;
 using _305.Application.Features.RoleFeatures.Response;
+using _305.Application.Features.PermissionFeatures.Response;
 using Newtonsoft.Json;
 
 namespace _305.Tests.Integration.Base.Helpers;
@@ -74,7 +75,7 @@ public class TestDataHelper(HttpClient client)
             { new StringContent("slug"), "slug" },
         };
 
-        return (await CreateAndGetIdAsync<UserResponse>(
+        return (await CreateAndGetIdAsync<PermissionResponse>(
             "/api/admin/permission/create", dto,
             "/api/admin/permission/get?slug="))?.id ?? 0;
     }

--- a/305.Tests.Integration/Base/JWT/IJwtProvider.cs
+++ b/305.Tests.Integration/Base/JWT/IJwtProvider.cs
@@ -1,0 +1,16 @@
+namespace _305.Tests.Integration.Base.JWT;
+
+public interface IJwtProvider
+{
+    string GenerateToken(
+        string userId = "1",
+        string userName = "test-user",
+        IEnumerable<string>? roles = null,
+        IDictionary<string, string>? extraClaims = null);
+
+    void AddTokenToClient(HttpClient client,
+        string? userId = null,
+        string? userName = null,
+        IEnumerable<string>? roles = null,
+        IDictionary<string, string>? extraClaims = null);
+}

--- a/305.Tests.Integration/Base/JWT/JwtTestHelper.cs
+++ b/305.Tests.Integration/Base/JWT/JwtTestHelper.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace _305.Tests.Integration.Base.JWT;
 
-public class JwtTestHelper
+public class JwtTestHelper : IJwtProvider
 {
     private readonly JwtSettings _jwtSettings;
 

--- a/305.Tests.Integration/Base/SyncPermissionsTest.cs
+++ b/305.Tests.Integration/Base/SyncPermissionsTest.cs
@@ -23,7 +23,7 @@ public class SyncPermissionsTest
 
         var db = _scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         await db.Database.EnsureDeletedAsync(); // پاک‌سازی دیتابیس
-        await db.Database.MigrateAsync();       // اعمال مایگریشن برای ایجاد جدول Permission
+        await db.Database.EnsureCreatedAsync(); // ایجاد جداول موردنیاز
 
         var seeder = new PermissionSeeder(_unitOfWork);
         await seeder.SyncPermissionsAsync();    // اجرای سیدر فقط اینجا

--- a/305.Tests.Integration/Base/TestController/BaseControllerTests.cs
+++ b/305.Tests.Integration/Base/TestController/BaseControllerTests.cs
@@ -11,7 +11,7 @@ public abstract class BaseControllerTests<TCreateDto, TKey, TEditDto, TResponse>
     protected HttpClient Client = null!;
     protected CustomWebApplicationFactory Factory = null!;
     protected string BaseUrl = null!;
-    private JwtTestHelper _jwtHelper = null!;
+    private IJwtProvider _jwtHelper = null!;
 
     [SetUp]
     public void Setup()
@@ -32,14 +32,14 @@ public abstract class BaseControllerTests<TCreateDto, TKey, TEditDto, TResponse>
     protected abstract MultipartFormDataContent CreateCreateForm(TCreateDto dto);
     protected abstract MultipartFormDataContent CreateEditForm(TEditDto dto);
 
-    protected virtual async Task<ResponseDto<TKey>?> DeserializeCreateResponse(string json)
-        => await Task.Run(() => JsonConvert.DeserializeObject<ResponseDto<TKey>>(json));
+    protected virtual Task<ResponseDto<TKey>?> DeserializeCreateResponse(string json)
+        => Task.FromResult(JsonConvert.DeserializeObject<ResponseDto<TKey>>(json));
 
-    protected virtual async Task<ResponseDto<TResponse>?> DeserializeEntityResponse(string json)
-        => await Task.Run(() => JsonConvert.DeserializeObject<ResponseDto<TResponse>>(json));
+    protected virtual Task<ResponseDto<TResponse>?> DeserializeEntityResponse(string json)
+        => Task.FromResult(JsonConvert.DeserializeObject<ResponseDto<TResponse>>(json));
 
-    protected virtual async Task<ResponseDto<PaginatedList<TResponse>>?> DeserializePaginatedResponse(string json)
-        => await Task.Run(() => JsonConvert.DeserializeObject<ResponseDto<PaginatedList<TResponse>>>(json));
+    protected virtual Task<ResponseDto<PaginatedList<TResponse>>?> DeserializePaginatedResponse(string json)
+        => Task.FromResult(JsonConvert.DeserializeObject<ResponseDto<PaginatedList<TResponse>>>(json));
 
     public async Task<TKey> CreateEntityAsync(TCreateDto dto)
     {


### PR DESCRIPTION
## Summary
- use SQLite in-memory DB in `CustomWebApplicationFactory`
- add `IJwtProvider` interface and implement it in `JwtTestHelper`
- refactor `BaseControllerTests` to depend on `IJwtProvider`
- fix `TestDataHelper.CreatePermissionAndReturnIdAsync` return type
- cleanup `SyncPermissionsTest` setup
- minor cleanup of deserialization helpers

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d6bd4be0083268e308c8ca6f9fb4b