### PR TITLE
Add user creation domain event and log

### DIFF
--- a/305.Application/Features/AdminUserFeatures/Handler/CreateAdminUserCommandHandler.cs
+++ b/305.Application/Features/AdminUserFeatures/Handler/CreateAdminUserCommandHandler.cs
@@ -6,6 +6,8 @@ using _305.Application.IUOW;
 using _305.BuildingBlocks.Helper;
 using _305.BuildingBlocks.Security;
 using _305.Domain.Entity;
+using _305.Domain.Events;
+using Serilog;
 using MediatR;
 
 namespace _305.Application.Features.AdminUserFeatures.Handler;
@@ -64,6 +66,8 @@ public class CreateAdminUserCommandHandler(IUnitOfWork unitOfWork)
                    slug = slug,
                };
                await unitOfWork.UserRepository.AddAsync(entity);
+               entity.AddDomainEvent(new UserCreatedDomainEvent(entity));
+               Log.Information("کاربر جدید با نامک {Slug} ایجاد شد", slug);
                return slug;
            },
            successMessage: null,

--- a/305.Domain/Common/BaseEntity.cs
+++ b/305.Domain/Common/BaseEntity.cs
@@ -1,4 +1,5 @@
 // حذف وابستگی به EF Core برای رعایت اصل SRP
+using System.Collections.Generic;
 
 namespace _305.Domain.Common;
 
@@ -34,6 +35,12 @@ public class BaseEntity : IBaseEntity
     public string slug { get; set; } = null!;
 
     /// <summary>
+    /// رویدادهای دامنه مرتبط با این موجودیت
+    /// </summary>
+    private readonly List<IDomainEvent> _domainEvents = new();
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    /// <summary>
     /// سازنده پیش‌فرض که تاریخ‌های ایجاد و به‌روزرسانی را تنظیم می‌کند
     /// </summary>
     public BaseEntity()
@@ -52,4 +59,9 @@ public class BaseEntity : IBaseEntity
         this.name = name;
         this.slug = slug;
     }
+
+    /// <summary>
+    /// افزودن رویداد دامنه به لیست رویدادها
+    /// </summary>
+    public void AddDomainEvent(IDomainEvent domainEvent) => _domainEvents.Add(domainEvent);
 }

--- a/305.Domain/Common/IBaseEntity.cs
+++ b/305.Domain/Common/IBaseEntity.cs
@@ -1,4 +1,5 @@
-﻿namespace _305.Domain.Common;
+﻿using System.Collections.Generic;
+namespace _305.Domain.Common;
 
 /// <summary>
 /// اینترفیس پایه برای تمام موجودیت‌ها (Entities) در سیستم
@@ -30,4 +31,9 @@ public interface IBaseEntity
     /// زمان آخرین بروزرسانی موجودیت (UTC)
     /// </summary>
     DateTime updated_at { get; }
+
+    /// <summary>
+    /// لیست رویدادهای دامنه مرتبط با این موجودیت
+    /// </summary>
+    IReadOnlyCollection<IDomainEvent> DomainEvents { get; }
 }

--- a/305.Domain/Common/IDomainEvent.cs
+++ b/305.Domain/Common/IDomainEvent.cs
@@ -1,0 +1,12 @@
+namespace _305.Domain.Common;
+
+/// <summary>
+/// اینترفیس پایه برای رویدادهای دامنه
+/// </summary>
+public interface IDomainEvent
+{
+    /// <summary>
+    /// زمان وقوع رویداد
+    /// </summary>
+    DateTime OccurredOn { get; }
+}

--- a/305.Domain/Events/UserCreatedDomainEvent.cs
+++ b/305.Domain/Events/UserCreatedDomainEvent.cs
@@ -1,0 +1,13 @@
+using _305.Domain.Common;
+using _305.Domain.Entity;
+
+namespace _305.Domain.Events;
+
+/// <summary>
+/// رویداد ایجاد کاربر جدید
+/// </summary>
+public class UserCreatedDomainEvent(User user) : IDomainEvent
+{
+    public User User { get; } = user;
+    public DateTime OccurredOn { get; } = DateTime.UtcNow;
+}


### PR DESCRIPTION
## Summary
- introduce `IDomainEvent` and update entity base classes to track domain events
- add `UserCreatedDomainEvent`
- emit the new domain event and log when an admin user is created

## Testing
- `dotnet test 305.WebApi/305.WebApi.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684feaa626a483269559b09596b44595